### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+The MIT License (MIT)
+Copyright © 2019 Remy Sharp, https://remysharp.com <remy@remysharp.com>
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Hi remy,

due to legal implications of how a distributed code can be used by some larger enterprises, there's an issue with the 1) repository and 2) the distributed `.tgz` of this package.

It might need the whole text of the MIT license to be present alongside the code that is published to `npm` registry to actually be usable as OSS.
Since e.g. `nodemon` depends on this package, it's really hard to use it properly for me and our team at Apiary.io, without being at least "partially" crossing a legal line into the grey area.

Thank you for accepting this PR, your work makes life of others a lot easier already.